### PR TITLE
Optimizations for reproject

### DIFF
--- a/src/LazyProjection/LazyProjection.jl
+++ b/src/LazyProjection/LazyProjection.jl
@@ -135,7 +135,7 @@ function compute_indices(a::LazyProjectedDiskArray, targetinds, index_arraybuffe
 end
 
 
-function make_indexbuffer(sourcetree, targettree, N=50)
+function make_indexbuffer(sourcetree, targettree, N=100)
     Nsource = ndims(sourcetree)
     Ntarget = ndims(targettree)
     [(CartesianIndex{Ntarget}[], CartesianIndex{Nsource}[]) for _ in 1:N]
@@ -153,7 +153,7 @@ function DiskArrays.readblock!(a::LazyProjectedDiskArray, aout, targetinds::Abst
     if length(chunks) < 8
         project_batched(a,outarray,chunks,isourcetrans,targetinds)
     else
-        project_sequential(a,outarray,chunks,isourcetrans,targetinds)
+        project_sequential(a,outarray,chunks,isourcetrans,targetinds;index_arraybuffer)
     end
 end
 

--- a/src/LazyProjection/batched.jl
+++ b/src/LazyProjection/batched.jl
@@ -1,0 +1,39 @@
+function project_kernel_batched!(::NearestProjection, outar, targetinds,sourcearrays, targettree, isourcetrans, lookups,chunks)
+    alllinind = LinearIndices(gridsize(targettree))
+    
+    Threads.@threads for targetindex in CartesianIndices(targetinds)
+        ind = alllinind[targetindex]
+        unit = index_to_unitsphere(ind, targettree)
+        sourcecoords = isourcetrans(unit)
+        sourceindices = map(sourcecoords,lookups) do coord,look
+            DD.selectindices(look, DD.Near(coord))
+        end
+        chunkindices = map((c,i)->findchunk(c.val,i),chunks,sourceindices)
+        cI = CartesianIndex(chunkindices)
+        outar[targetindex] = sourcearrays[cI][sourceindices...]
+    end
+    outar
+end
+
+function load_sourcechunks(source,chunks)
+    input_chunks = map(chunks) do c
+        chunk_cartindex = CartesianIndex(index_to_cartesian(c,source.chunktree))
+        sourceindices = indices_from_chunk(source,c)
+        aout = source.ar.data[sourceindices...]
+        data = OffsetArray(aout,sourceindices...)
+        chunk_cartindex => data
+    end
+    i1,i2 = extrema(first,input_chunks)
+    s = (i2.-i1+oneunit(i1)).I
+    et = typeof(last(first(input_chunks)))
+    sourcearrays = OffsetArray(Matrix{et}(undef,s...),(i1-oneunit(i1)).I...)
+    for (i,a) in input_chunks
+        sourcearrays[i]=a
+    end
+    sourcearrays
+end
+
+function project_batched(a::LazyProjectedDiskArray,outarray,chunks,isourcetrans,targetinds)
+    sourcearrays = load_sourcechunks(a.source,chunks)
+    project_kernel_batched!(NearestProjection(),outarray,targetinds,sourcearrays, a.target.tree, isourcetrans, a.source.lookups,a.source.chunks)
+end

--- a/src/LazyProjection/sequential.jl
+++ b/src/LazyProjection/sequential.jl
@@ -1,0 +1,49 @@
+function copy_sequential(outarray, inds, source)
+    for (vt, vs) in inds
+        i1,i2 = extrema(vs)
+        bbr = map(Colon(),i1.I,i2.I)
+        data = OffsetArray(source[bbr...], bbr...)
+        outarray[vt] = data[vs]
+    end
+end
+
+function project_sequential(a::LazyProjectedDiskArray,outarray,chunks,isourcetrans,targetinds)
+    indices_per_chunk = precompute_sequential_weights(targetinds, a.target.tree, isourcetrans, a.source.lookups, s.source.chunks, index_arraybuffer)
+    copy_sequential(outarray,indices_per_chunk,a.source.ar)
+end
+
+
+function precompute_sequential_weights(targetinds, targettree, isourcetrans, lookups::Tuple{Vararg{<:Any,Nsource}}, chunks, index_arraybuffer) where Nsource
+    alllinind = LinearIndices(gridsize(targettree))
+    #Ntarget = ndims(targettree)
+    inner_indexarray = fill((zero(CartesianIndex{Nsource}), zero(CartesianIndex{Nsource})), length.(targetinds)...)
+    indexarray = OffsetArray(inner_indexarray, targetinds...)
+    Threads.@threads for targetindex in CartesianIndices(targetinds)
+        ind = alllinind[targetindex]
+        unit = index_to_unitsphere(ind, targettree)
+        sourcecoords = isourcetrans(unit)
+        sourceindices = map(sourcecoords,lookups) do coord,look
+            DD.selectindices(look, DD.Near(coord))
+        end
+        chunkindices = map((c,i)->findchunk(c.val,i),chunks,sourceindices)
+        cI = CartesianIndex(chunkindices)
+        indexarray[targetindex] = (cI, CartesianIndex(sourceindices))
+    end
+    cartinds = first.(unique(first, indexarray))
+    if length(cartinds) > length(index_arraybuffer)
+        error("Too many connected chunks")
+    end
+    mybuffer = view(index_arraybuffer, 1:length(cartinds))
+    foreach(mybuffer) do b
+        empty!(first(b))
+        empty!(last(b))
+    end
+    for itarget in CartesianIndices(indexarray)
+        chunknum, iel = indexarray[itarget]
+        ichunk = findfirst(==(chunknum), cartinds)
+        vt, vs = index_arraybuffer[ichunk]
+        push!(vt, itarget)
+        push!(vs, iel)
+    end
+    return mybuffer
+end

--- a/src/LazyProjection/sequential.jl
+++ b/src/LazyProjection/sequential.jl
@@ -2,13 +2,19 @@ function copy_sequential(outarray, inds, source)
     for (vt, vs) in inds
         i1,i2 = extrema(vs)
         bbr = map(Colon(),i1.I,i2.I)
-        data = OffsetArray(source[bbr...], bbr...)
+        data = OffsetArray(DD.data(source)[bbr...], bbr...)
         outarray[vt] = data[vs]
     end
 end
 
-function project_sequential(a::LazyProjectedDiskArray,outarray,chunks,isourcetrans,targetinds)
-    indices_per_chunk = precompute_sequential_weights(targetinds, a.target.tree, isourcetrans, a.source.lookups, s.source.chunks, index_arraybuffer)
+function make_indexbuffer(sourcetree, targettree, N=50)
+    Nsource = ndims(sourcetree)
+    Ntarget = ndims(targettree)
+    [(CartesianIndex{Ntarget}[], CartesianIndex{Nsource}[]) for _ in 1:N]
+end
+
+function project_sequential(a::LazyProjectedDiskArray,outarray,chunks,isourcetrans,targetinds; index_arraybuffer=make_indexbuffer(a.source.tree,a.target.tree))
+    indices_per_chunk = precompute_sequential_weights(targetinds, a.target.tree, isourcetrans, a.source.lookups, a.source.chunks, index_arraybuffer)
     copy_sequential(outarray,indices_per_chunk,a.source.ar)
 end
 

--- a/src/RegularGridTree.jl
+++ b/src/RegularGridTree.jl
@@ -139,9 +139,10 @@ end
 #     UnitSpherical._merge(cap1, cap2)
 # end
 
-function get_subtree(source_tree::RegularGridTree, target_chunk, target_tree::RegularGridTree, chunksx, chunksy)
-    ix, iy = index_to_cartesian(target_chunk, source_tree)
-    ix1, ix2 = extrema(chunksx[ix])
-    iy1, iy2 = extrema(chunksy[iy])
-    TreeNode(target_tree, TreeIndex((ix1, ix2), (iy1, iy2)))
+
+function get_subtree(tree::RegularGridTree,targetinds)
+    r1,r2 = targetinds
+    ix1,ix2 = first(r1), last(r1)
+    iy1,iy2 = first(r2), last(r2)
+    TreeNode(tree, TreeIndex((ix1, ix2), (iy1, iy2)))
 end

--- a/src/RegularGridTree.jl
+++ b/src/RegularGridTree.jl
@@ -15,6 +15,11 @@ struct RegularGridTree{DX,DY,T,S}
     tag::S
 end
 Base.ndims(t::RegularGridTree) = 2
+gridsize(t::RegularGridTree) = (length(t.x)-1,length(t.y)-1)
+function get_gridextent(t::RegularGridTree, xr::AbstractUnitRange, yr::AbstractUnitRange)
+    t = TreeNode(t, TreeIndex((first(xr), last(xr) + 1), (first(yr), last(yr) + 1)))
+    node_extent(t)
+end
 get_projection(t::RegularGridTree) = t.trans
 """
     RegularGridTree(x, y, transform=UnitSphereFromGeographic())

--- a/src/SphericalSpatialTrees.jl
+++ b/src/SphericalSpatialTrees.jl
@@ -18,7 +18,6 @@ include("LazyProjection/LazyProjection.jl")
 
 function index_to_lonlat(i::Integer, t)
     uind = index_to_unitsphere(i, t)
-    @show uind
     GeographicFromUnitSphere()(uind)
 end
 

--- a/src/SphericalSpatialTrees.jl
+++ b/src/SphericalSpatialTrees.jl
@@ -1,7 +1,7 @@
 module SphericalSpatialTrees
 
 import GeoFormatTypes as GFT, GeometryOps as GO, GeoInterface as GI
-
+import GeometryOps.LoopStateMachine: Action
 export RegularGridTree
 
 
@@ -42,6 +42,18 @@ function find_nearest(tree, point)
         end
     end
     cur[]
+end
+
+function any_intersect(tree1, tree2)
+    r = dual_depth_first_search(_intersects, tree1, tree2) do n1, n2
+        return Action(:full_return,true)
+    end
+    if r === nothing
+        return false
+    else
+        return true
+    end
+
 end
 
 

--- a/src/SphericalSpatialTrees.jl
+++ b/src/SphericalSpatialTrees.jl
@@ -12,12 +12,13 @@ include("RegularGridTree.jl")
 #Implementation of a spherical tree for isea grid on 10 diamonds
 include("iseatree.jl")
 #Reprojection code
-include("LazyProjection.jl")
+include("LazyProjection/LazyProjection.jl")
 
 
 
 function index_to_lonlat(i::Integer, t)
     uind = index_to_unitsphere(i, t)
+    @show uind
     GeographicFromUnitSphere()(uind)
 end
 

--- a/src/iseatree.jl
+++ b/src/iseatree.jl
@@ -42,6 +42,8 @@ function get_xyranges(t::ISEACircleTree)
     t.xr,t.yr
 end
 
+
+getchild(t::ISEACircleTree, i::AbstractVector) = getchild(t,only(i))
 function getchild(t::ISEACircleTree, i)
     xr,yr = get_xyranges(t)
     t1 = inv(ISEA10(t.isea)) ∘ InvRotateISEA() ∘ PickPlane(i)
@@ -76,37 +78,21 @@ function index_to_polygon_unitsphere(i::CartesianIndex,t::ISEACircleTree)
 end
 
 
-
 """
     get_subtree(source_tree, target_chunk, target_tree)
 
 Expands the target chunk to to the full subtree containing all grid cells at the target resolution.
 """
-function get_subtree(source_tree::ISEACircleTree, target_chunk, target_tree::ISEACircleTree)
-    ix, iy, n = lin_to_cart(target_chunk + 1, source_tree)
-    resolution_difference = target_tree.resolution - source_tree.resolution
-    fac = 2^resolution_difference
-    ix1 = (ix - 1) * fac + 1
-    iy1 = (iy - 1) * fac + 1
-    ix2 = ix1 + fac
-    iy2 = iy1 + fac
-    gridtree = getchild(target_tree, n).grid
-    xsub = gridtree.x[ix1:ix2]
-    ysub = gridtree.y[iy1:iy2]
+function get_subtree(tree::ISEACircleTree, target_indices)
+    ix,iy,n = target_indices
+    gridtree = getchild(tree, n).grid
+    xsub = gridtree.x[ix]
+    ysub = gridtree.y[iy]
     trsmall = RegularGridTree(xsub,ysub,gridtree.trans,gridtree.tag)
     rootnode(trsmall)
 end
 
-function get_subindices(source_tree::ISEACircleTree, target_chunk, target_tree::ISEACircleTree)
-    ix, iy, n = lin_to_cart(target_chunk, source_tree)
-    resolution_difference = target_tree.resolution - source_tree.resolution
-    fac = 2^resolution_difference
-    ix1 = (ix - 1) * fac + 1
-    iy1 = (iy - 1) * fac + 1
-    ix2 = ix1 + fac -1 
-    iy2 = iy1 + fac -1
-    ix1:ix2, iy1:iy2, n
-end
+
 
 struct ProjectionTarget{T,CT}
     tree::T
@@ -132,3 +118,21 @@ function create_dataset(target::ProjectionTarget{<:ISEACircleTree},
     ds = Dataset(;properties=datasetmeta,p...)
     ds = savedataset(ds,path = path, skeleton=true, overwrite=true)
 end
+
+
+# """
+#     indices_from_chunk(s::ISEASourceOrTarget, target_indices)
+
+# For a given index from the chunk tree, returns the cartesian index ranges 
+# in the high-resolution tree
+# """
+# function indices_from_chunk(s::ISEASource, target_chunk)
+#     ix, iy, n = lin_to_cart(target_chunk + 1, s.chunktree)
+#     resolution_difference = s.tree.resolution - s.chunktree.resolution
+#     fac = 2^resolution_difference
+#     ix1 = (ix - 1) * fac + 1
+#     iy1 = (iy - 1) * fac + 1
+#     ix2 = ix1 + fac
+#     iy2 = iy1 + fac
+#     return ix1:ix2, iy1:iy2, n
+# end

--- a/src/iseatree.jl
+++ b/src/iseatree.jl
@@ -105,6 +105,7 @@ function ProjectionTarget(::Type{ISEACircleTree},target_resolution, chunk_resolu
     ProjectionTarget(tree,chunktree)
 end
 
+
 function create_dataset(target::ProjectionTarget{<:ISEACircleTree}, 
     path; arrayname=:layer, arraymeta=Dict(), datasetmeta=Dict())
     outdims = (DD.Dim{:dggs_i}(0:(2^target.tree.resolution-1)),


### PR DESCRIPTION
@asinghvi17 this implements the changes we discussed. We first compute only the chunks we really need for reprocessing and then load all of them before running the reproject loop. This really speeds up large batch processing. However, accessing small subsets of data (e.g. 256x256 windows), with source chunk size of 2025x2025 is slower now, because in this case data loading of the 2000x2000 array is slower than the reprojection work. However, this can easily be mended with making chunks smaller through manual Mockchunks. 